### PR TITLE
fix thread conflict when passing local arg as pointer

### DIFF
--- a/httpd.c
+++ b/httpd.c
@@ -25,6 +25,7 @@
 #include <pthread.h>
 #include <sys/wait.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #define ISspace(x) isspace((int)(x))
 
@@ -53,7 +54,7 @@ void unimplemented(int);
 /**********************************************************************/
 void accept_request(void *arg)
 {
-    int client = *(int*)arg;
+    int client = (intptr_t)arg;
     char buf[1024];
     size_t numchars;
     char method[255];
@@ -500,7 +501,7 @@ int main(void)
         if (client_sock == -1)
             error_die("accept");
         /* accept_request(client_sock); */
-        if (pthread_create(&newthread , NULL, (void *)accept_request, (void *)&client_sock) != 0)
+        if (pthread_create(&newthread , NULL, (void *)accept_request, (void *)(intptr_t)client_sock) != 0)
             perror("pthread_create");
     }
 


### PR DESCRIPTION
创建线程时，传递局部变量的指针会导致竞争。可以以pass-by-value的方式传递client_sock到线程中，从而避免竞争。 @EZLippi 
