### PR TITLE
fix cat #31

### DIFF
--- a/httpd.c
+++ b/httpd.c
@@ -164,11 +164,9 @@ void cat(int client, FILE *resource)
 {
     char buf[1024];
 
-    fgets(buf, sizeof(buf), resource);
-    while (!feof(resource))
+    while (fgets(buf, sizeof(buf), resource) != NULL)
     {
         send(client, buf, strlen(buf), 0);
-        fgets(buf, sizeof(buf), resource);
     }
 }
 


### PR DESCRIPTION
解决 cat函数在读取文件的字符数小于fget的单次读取数时 出现的问题 